### PR TITLE
Healthz endpoint improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Build
         run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.encore.dev/emissary
 
-go 1.17
+go 1.18
 
 require (
 	github.com/cockroachdb/errors v1.9.0

--- a/server/example.env
+++ b/server/example.env
@@ -18,3 +18,6 @@ EMISSARY_AUTH_KEYS='[{ "kid": 1, "data": "c29tZSBzdXBlciBzZWNyZXQgcmFuZG9taXNlZC
 
 # The DNS servers to use, as a space-separated list.
 EMISSARY_DNS_SERVERS='1.1.1.1 8.8.8.8'
+
+# The path to the health check endpoint
+EMISSARY_HEALTH_PATH='/health'

--- a/server/http/healthz.go
+++ b/server/http/healthz.go
@@ -1,10 +1,23 @@
 package http
 
 import (
+	"encoding/json"
 	"net/http"
+
+	"go.encore.dev/emissary/server/proxy"
 )
 
-func handleHealth(w http.ResponseWriter, _ *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{ "ok": true }`))
+func handleHealth(cfg *proxy.Config) func(w http.ResponseWriter, _ *http.Request) {
+	keys := make([]uint32, 0, len(cfg.AuthKeys))
+	for _, key := range cfg.AuthKeys {
+		keys = append(keys, key.KeyID)
+	}
+	healthResponse, _ := json.Marshal(map[string]interface{}{
+		"ok":      true,
+		"key_ids": keys,
+	})
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(healthResponse)
+	}
 }

--- a/server/http/server.go
+++ b/server/http/server.go
@@ -21,7 +21,7 @@ func StartServer(ctx context.Context, config *proxy.Config) error {
 	// Setup the router
 	var router = mux.NewRouter()
 	router.Use(PanicRecovery(), RequestLogger())
-	router.Methods("GET").PathPrefix("/healthz").Handler(http.HandlerFunc(handleHealth))
+	router.Methods("GET").PathPrefix(config.HealthPath).Handler(http.HandlerFunc(handleHealth(config)))
 	router.Methods("GET").PathPrefix("/").Handler(handleProxy(config))
 
 	// Start the server

--- a/server/proxy/config.go
+++ b/server/proxy/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	AuthKeys            auth.Keys           // What auth keys can be used when talking with this Emissary server
 	AllowedProxyTargets AllowedProxyTargets // What proxy targets are allowed through this Emissary server
 	DNSServers          []string            // The DNS server IPs to use; nil means the system default
+	HealthPath          string              // The path to use for health checks
 }
 
 // LoadConfig performs setup for the proxy layer and returns an error if we cannot initialise
@@ -29,6 +30,7 @@ func LoadConfig(_ context.Context) (*Config, error) {
 
 	// Now configure viper with our default config and bind it to read from the environment
 	viper.SetDefault("http_port", 8080)
+	viper.SetDefault("health_path", "/healthz")
 	viper.SetEnvPrefix("emissary")
 	viper.AutomaticEnv()
 
@@ -80,5 +82,6 @@ func LoadConfig(_ context.Context) (*Config, error) {
 		AuthKeys:            authKeys,
 		AllowedProxyTargets: allowedProxyTargets,
 		DNSServers:          viper.GetStringSlice("dns_servers"),
+		HealthPath:          viper.GetString("health_path"),
 	}, nil
 }


### PR DESCRIPTION
* Adds configurable health path
  * The `/healthz` path is reserved for CloudRun instances and cannot be used for health checks. 
* Returns the accepted key ids in the health response
  * This is needed for validating that new keys have been successfully deployed  
